### PR TITLE
export-esm-by-default 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
       "import": "./es-modules/masters/grid-pro.src.js",
       "types": "./es-modules/masters/grid-pro.src.d.ts",
       "require": "./grid-pro.js"
-    }
+    },
+    "./*": "./*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Set "exports" param in `package.json` to export es-modules by default.