### PR TITLE
esm-unstrict-path-ext

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,6 @@
   "main": "grid-pro.js",
   "module": "./es-modules/masters/grid-pro.src.js",
   "types": "./es-modules/masters/grid-pro.src.d.ts",
-  "exports": {
-    ".": {
-      "import": "./es-modules/masters/grid-pro.src.js",
-      "types": "./es-modules/masters/grid-pro.src.d.ts",
-      "require": "./grid-pro.js"
-    },
-    "./*": "./*"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/highcharts/grid-pro-dist"


### PR DESCRIPTION
Fixed an issue where non-default imports had to have a 100% path match including extension.
